### PR TITLE
Add error_count property to Hedwig consumer backend for HC implementation

### DIFF
--- a/hedwig/backends/aws.py
+++ b/hedwig/backends/aws.py
@@ -119,10 +119,10 @@ class AWSSQSConsumerBackend(HedwigConsumerBaseBackend):
     WAIT_TIME_SECONDS = 20
 
     def __init__(self, dlq=False):
+        super().__init__()
         self._sqs_resource = None
         self._sqs_client = None
         self.queue_name = f'HEDWIG-{settings.HEDWIG_QUEUE}{"-DLQ" if dlq else ""}'
-        self._error_count = 0
 
     @property
     def sqs_resource(self):

--- a/hedwig/backends/aws.py
+++ b/hedwig/backends/aws.py
@@ -122,6 +122,7 @@ class AWSSQSConsumerBackend(HedwigConsumerBaseBackend):
         self._sqs_resource = None
         self._sqs_client = None
         self.queue_name = f'HEDWIG-{settings.HEDWIG_QUEUE}{"-DLQ" if dlq else ""}'
+        self._error_count = 0
 
     @property
     def sqs_resource(self):

--- a/hedwig/backends/base.py
+++ b/hedwig/backends/base.py
@@ -150,6 +150,8 @@ class HedwigConsumerBaseBackend:
 
                     try:
                         self.process_message(queue_message)
+                        if self._error_count:  # type: ignore
+                            self._error_count = 0
                     except IgnoreException:
                         log(__name__, logging.INFO, 'Ignoring task', extra={'queue_message': queue_message})
                     except LoggingException as e:
@@ -165,6 +167,7 @@ class HedwigConsumerBaseBackend:
                     except Exception:
                         log(__name__, logging.ERROR, 'Exception while processing message', exc_info=True)
                         self.nack_message(queue_message)
+                        self._error_count += 1
                         continue
 
                     try:
@@ -245,6 +248,17 @@ class HedwigConsumerBaseBackend:
         except ValidationError:
             _log_invalid_message(message_payload)
             raise
+
+    @property
+    def error_count(self) -> int:
+        """
+        Returns the number of consecutive errors occurred when trying to process messages from the queue.
+
+        Resets to 0 when a message is successfully processed.
+
+        :return: Number of consecutive errors
+        """
+        return self._error_count
 
 
 def log_published_message(message: Message, result: Union[str, Future]) -> None:

--- a/hedwig/backends/base.py
+++ b/hedwig/backends/base.py
@@ -87,6 +87,9 @@ class HedwigPublisherBaseBackend:
 
 
 class HedwigConsumerBaseBackend:
+    def __init__(self) -> None:
+        self._error_count = 0
+
     @staticmethod
     def pre_process_hook_kwargs(queue_message) -> dict:
         return {}

--- a/hedwig/backends/gcp.py
+++ b/hedwig/backends/gcp.py
@@ -198,9 +198,9 @@ class PubSubMessageScheduler(Scheduler):
 
 class GooglePubSubConsumerBackend(HedwigConsumerBaseBackend):
     def __init__(self, dlq=False) -> None:
+        super().__init__()
         self._subscriber: pubsub_v1.SubscriberClient = None
         self._publisher: pubsub_v1.PublisherClient = None
-        self._error_count = 0
 
         if not settings.HEDWIG_SYNC:
             cloud_project = get_google_cloud_project()

--- a/hedwig/backends/gcp.py
+++ b/hedwig/backends/gcp.py
@@ -200,6 +200,7 @@ class GooglePubSubConsumerBackend(HedwigConsumerBaseBackend):
     def __init__(self, dlq=False) -> None:
         self._subscriber: pubsub_v1.SubscriberClient = None
         self._publisher: pubsub_v1.PublisherClient = None
+        self._error_count = 0
 
         if not settings.HEDWIG_SYNC:
             cloud_project = get_google_cloud_project()


### PR DESCRIPTION
Add error_count property to consumer backend that increases on every exception raised by processing messages and resets when a message is successfully processed.