### PR TITLE
Add option to reset error counter after inactivity period

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -136,6 +136,12 @@ It's recommended that this function be declared with ``**kwargs`` so it doesn't 
 
 optional; fully-qualified function name
 
+**HEDWIG_HEARTBEAT_INACTIVITY_RESET_S**
+
+Hedwig heartbeat inactivity interval in seconds. If ``HEDWIG_HEARTBEAT_INACTIVITY_RESET_S`` is defined, the hedwig error counter value is non-zero and there are no new messages in queue for the given period of time, then the error counter is reset.
+
+optional; int; default: null
+
 **HEDWIG_HEARTBEAT_INTERVAL_S**
 
 Hedwig heartbeat event interval in seconds. It defines minimum time interval between heartbeat hook method calls.

--- a/hedwig/backends/aws.py
+++ b/hedwig/backends/aws.py
@@ -177,6 +177,7 @@ class AWSSQSConsumerBackend(HedwigConsumerBaseBackend):
         try:
             return self._get_queue().receive_messages(**params)
         finally:
+            self._perform_error_counter_inactivity_reset()
             self._call_heartbeat_hook()
 
     def process_message(self, queue_message) -> None:

--- a/hedwig/backends/gcp.py
+++ b/hedwig/backends/gcp.py
@@ -278,6 +278,7 @@ class GooglePubSubConsumerBackend(HedwigConsumerBaseBackend):
                 message = work_queue.get(timeout=1)
                 yield message
             except Empty:
+                self._perform_error_counter_inactivity_reset()
                 self._call_heartbeat_hook()
 
         for future in futures:
@@ -288,6 +289,7 @@ class GooglePubSubConsumerBackend(HedwigConsumerBaseBackend):
             while True:
                 yield work_queue.get(block=False)
         except Empty:
+            self._perform_error_counter_inactivity_reset()
             self._call_heartbeat_hook()
 
     def process_message(self, queue_message: MessageWrapper) -> None:

--- a/hedwig/conf/__init__.py
+++ b/hedwig/conf/__init__.py
@@ -40,6 +40,7 @@ _DEFAULTS: dict = {
     'HEDWIG_CONSUMER_BACKEND': None,
     'HEDWIG_DATA_VALIDATOR_CLASS': 'hedwig.validators.jsonschema.JSONSchemaValidator',
     'HEDWIG_DEFAULT_HEADERS': 'hedwig.conf.default_headers_hook',
+    'HEDWIG_HEARTBEAT_INACTIVITY_RESET_S': None,
     'HEDWIG_HEARTBEAT_INTERVAL_S': 15,
     'HEDWIG_HEARTBEAT_HOOK': 'hedwig.conf.noop_hook',
     'HEDWIG_MESSAGE_ROUTING': {},

--- a/tests/test_backends/test_aws.py
+++ b/tests/test_backends/test_aws.py
@@ -159,12 +159,7 @@ class TestSQSConsumer:
         "inactivity_s,expected_error_count", [(None, 1), (1, 0)], ids=["reset-disabled", "reset-enabled"]
     )
     def test_pull_messages_error_count_inactivity_reset(
-            self,
-            mock_boto3,
-            settings,
-            prepost_process_hooks,
-            inactivity_s,
-            expected_error_count
+        self, mock_boto3, settings, prepost_process_hooks, inactivity_s, expected_error_count
     ):
         num_messages = 1
         visibility_timeout = 10

--- a/tests/test_backends/test_aws.py
+++ b/tests/test_backends/test_aws.py
@@ -155,6 +155,30 @@ class TestSQSConsumer:
         )
         heartbeat_hook.assert_called_once_with(error_count=0)
 
+    @pytest.mark.parametrize(
+        "inactivity_s,expected_error_count", [(None, 1), (1, 0)], ids=["reset-disabled", "reset-enabled"]
+    )
+    def test_pull_messages_error_count_inactivity_reset(
+            self,
+            mock_boto3,
+            settings,
+            prepost_process_hooks,
+            inactivity_s,
+            expected_error_count
+    ):
+        num_messages = 1
+        visibility_timeout = 10
+        queue = mock.MagicMock()
+        settings.HEDWIG_HEARTBEAT_INACTIVITY_RESET_S = inactivity_s
+        sqs_consumer = aws.AWSSQSConsumerBackend()
+        sqs_consumer.sqs_resource.get_queue_by_name = mock.MagicMock(return_value=queue)
+        sqs_consumer._error_count = 1
+
+        sqs_consumer.pull_messages(num_messages, visibility_timeout)
+
+        assert sqs_consumer._error_count == expected_error_count
+        heartbeat_hook.assert_called_once_with(error_count=expected_error_count)
+
     def test_extend_visibility_timeout(self, sqs_consumer, prepost_process_hooks):
         visibility_timeout_s = 10
         receipt = "receipt"

--- a/tests/test_backends/test_gcp.py
+++ b/tests/test_backends/test_gcp.py
@@ -201,13 +201,13 @@ class TestGCPConsumer:
         "inactivity_s,expected_error_count", [(None, 1), (1, 0)], ids=["reset-disabled", "reset-enabled"]
     )
     def test_pull_messages_error_count_inactivity_reset(
-            self,
-            mock_pubsub_v1,
-            gcp_settings,
-            subscription_paths,
-            prepost_process_hooks,
-            inactivity_s,
-            expected_error_count
+        self,
+        mock_pubsub_v1,
+        gcp_settings,
+        subscription_paths,
+        prepost_process_hooks,
+        inactivity_s,
+        expected_error_count,
     ):
         shutdown_event = threading.Event()
         num_messages = 1

--- a/tests/test_backends/test_gcp.py
+++ b/tests/test_backends/test_gcp.py
@@ -209,19 +209,25 @@ class TestGCPConsumer:
         inactivity_s,
         expected_error_count,
     ):
-        shutdown_event = threading.Event()
+        class _Event(threading.Event):
+            def __init__(self, max_calls):
+                super().__init__()
+                self.max_calls = max_calls
+                self.counter = 0
+
+            def is_set(self):
+                if self.counter == self.max_calls:
+                    self.set()
+                self.counter += 1
+                return super().is_set()
+
+        shutdown_event = _Event(max_calls=1)
         num_messages = 1
         visibility_timeout = 10
         mock_pubsub_v1.SubscriberClient.subscription_path.side_effect = subscription_paths
         gcp_settings.HEDWIG_HEARTBEAT_INACTIVITY_RESET_S = inactivity_s
         gcp_consumer = gcp.GooglePubSubConsumerBackend()
         gcp_consumer._error_count = 1
-
-        def subscribe_side_effect(subscription_path, callback, flow_control, scheduler):
-            shutdown_event.set()
-            return mock.Mock()
-
-        gcp_consumer.subscriber.subscribe.side_effect = subscribe_side_effect
 
         list(gcp_consumer.pull_messages(num_messages, visibility_timeout, shutdown_event=shutdown_event))
 


### PR DESCRIPTION
This option is dedicated for a consumer, which processes very low number of messages. If an error is raised during a message processing, it increments an error counter. If queue massage rate is low and new messages appear occasionally, then the hedwig error state may indicate that service is broken, even if there is no activity. This option clears an alert state after given inactivity period.