### PR TITLE
Fix GCP pubsub message scheduler shutdown method return type

### DIFF
--- a/hedwig/backends/gcp.py
+++ b/hedwig/backends/gcp.py
@@ -190,10 +190,11 @@ class PubSubMessageScheduler(Scheduler):
         # callback is unused since we never set it in pull_messages
         self._work_queue.put(MessageWrapper(message, self._subscription_path))
 
-    def shutdown(self, await_msg_callbacks=False) -> None:
+    def shutdown(self, await_msg_callbacks=False) -> List[SubscriberMessage]:
         """Shuts down the scheduler and immediately end all pending callbacks."""
         # ideally we'd nack the messages in work queue, but that might take some time to finish.
         # instead, it's faster to actually process all the messages
+        return []
 
 
 class GooglePubSubConsumerBackend(HedwigConsumerBaseBackend):


### PR DESCRIPTION
Fix GCP pubsub message scheduler shutdown method return type

Scheduler shutdown should return list of messages:
https://github.com/googleapis/python-pubsub/blob/main/google/cloud/pubsub_v1/subscriber/scheduler.py#L65
When `None` is returned instead, gcp consumer process raises `TypeError: object of type 'NoneType' has no len()`  exception during shutdown here:
https://github.com/googleapis/python-pubsub/blob/main/google/cloud/pubsub_v1/subscriber/_protocol/streaming_pull_manager.py#L984